### PR TITLE
日記のコントローラのサンプルを追加

### DIFF
--- a/src/spring-backend/api-docs/web/api-specification.json
+++ b/src/spring-backend/api-docs/web/api-specification.json
@@ -10,6 +10,123 @@
       "description": "Generated server url"
     }
   ],
-  "paths": {},
-  "components": {}
+  "tags": [
+    {
+      "description": "日記の情報にアクセスするAPI",
+      "name": "Diary"
+    }
+  ],
+  "paths": {
+    "/api/diary": {
+      "post": {
+        "operationId": "postDiary",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PostDiaryRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "*/*": {
+                "schema": {}
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "tags": [
+          "Diary"
+        ]
+      }
+    },
+    "/api/diary/{date}": {
+      "get": {
+        "operationId": "getDiary",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "date",
+            "required": true,
+            "schema": {
+              "type": [
+                "integer"
+              ],
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetDiaryResponse"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "tags": [
+          "Diary"
+        ]
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "GetDiaryResponse": {
+        "type": [
+          "object"
+        ],
+        "properties": {
+          "content": {
+            "type": [
+              "string"
+            ]
+          },
+          "date": {
+            "type": [
+              "string"
+            ],
+            "format": "date"
+          },
+          "title": {
+            "type": [
+              "string"
+            ]
+          }
+        }
+      },
+      "PostDiaryRequest": {
+        "type": [
+          "object"
+        ],
+        "properties": {
+          "content": {
+            "type": [
+              "string"
+            ]
+          },
+          "date": {
+            "type": [
+              "string"
+            ],
+            "format": "date"
+          },
+          "title": {
+            "type": [
+              "string"
+            ]
+          }
+        }
+      }
+    }
+  }
 }

--- a/src/spring-backend/application-core/src/main/java/com/memoblend/applicationcore/diary/Diary.java
+++ b/src/spring-backend/application-core/src/main/java/com/memoblend/applicationcore/diary/Diary.java
@@ -1,8 +1,16 @@
 package com.memoblend.applicationcore.diary;
 
+import java.time.LocalDate;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
 /**
  * 日記のドメインモデルです。
  */
+@Data
+@AllArgsConstructor
 public class Diary {
-
+  private LocalDate date;
+  private String title;
+  private String content;
 }

--- a/src/spring-backend/system-common/src/main/java/com/memoblend/systemcommon/util/LocalDateConverter.java
+++ b/src/spring-backend/system-common/src/main/java/com/memoblend/systemcommon/util/LocalDateConverter.java
@@ -1,0 +1,28 @@
+package com.memoblend.systemcommon.util;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+
+/**
+ * 日付の変換を行うクラスです。
+ */
+public class LocalDateConverter {
+
+  /**
+   * long型の日付をLocalDate型に変換します。
+   * 
+   * @param date long型の日付
+   * @return LocalDate型の日付
+   */
+  public static LocalDate longToLocalDate(long date) {
+    try {
+      String dateString = String.valueOf(date);
+      DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyyMMdd");
+      LocalDate localDate = LocalDate.parse(dateString, formatter);
+      return localDate;
+    } catch (DateTimeParseException e) {
+      throw new IllegalArgumentException("日付の形式が正しくありません: " + date, e);
+    }
+  }
+}

--- a/src/spring-backend/web/src/main/java/com/memoblend/web/controller/DiaryController.java
+++ b/src/spring-backend/web/src/main/java/com/memoblend/web/controller/DiaryController.java
@@ -1,8 +1,54 @@
 package com.memoblend.web.controller;
 
+import org.springframework.web.bind.annotation.RestController;
+import com.memoblend.applicationcore.diary.Diary;
+import com.memoblend.systemcommon.util.LocalDateConverter;
+import com.memoblend.web.controller.dto.diary.GetDiaryResponse;
+import com.memoblend.web.controller.dto.diary.PostDiaryRequest;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.AllArgsConstructor;
+import java.net.URI;
+import java.time.LocalDate;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
 /**
  * 日記情報の操作を行うコントローラークラスです。
  */
+@RestController
+@RequestMapping("api/diary")
+@Tag(name = "Diary", description = "日記の情報にアクセスするAPI")
+@AllArgsConstructor
 public class DiaryController {
+  /**
+   * 日記情報を取得します。
+   * 
+   * @param date 日記の日付
+   * @return 日記情報
+   */
+  @GetMapping("{date}")
+  public ResponseEntity<GetDiaryResponse> getDiary(@PathVariable("date") long date) {
+    LocalDate convertedDate = LocalDateConverter.longToLocalDate(date);
+    GetDiaryResponse response = new GetDiaryResponse(
+        convertedDate,
+        "タイトル",
+        "本文");
+    return ResponseEntity.ok().body(response);
+  }
 
+  /**
+   * 日記情報を登録します。
+   * 
+   * @param request 日記情報
+   * @return 登録結果
+   */
+  @PostMapping
+  public ResponseEntity<?> postDiary(@RequestBody PostDiaryRequest request) {
+    Diary addedDiary = new Diary(request.getDate(), request.getTitle(), request.getContent());
+    return ResponseEntity.created(URI.create("/api/diary/" + addedDiary.getDate())).build();
+  }
 }

--- a/src/spring-backend/web/src/main/java/com/memoblend/web/controller/dto/diary/GetDiaryResponse.java
+++ b/src/spring-backend/web/src/main/java/com/memoblend/web/controller/dto/diary/GetDiaryResponse.java
@@ -1,8 +1,16 @@
 package com.memoblend.web.controller.dto.diary;
 
+import java.time.LocalDate;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
 /**
  * 日記の取得レスポンスクラスです。
  */
+@Data
+@AllArgsConstructor
 public class GetDiaryResponse {
-
+  private LocalDate date;
+  private String title;
+  private String content;
 }

--- a/src/spring-backend/web/src/main/java/com/memoblend/web/controller/dto/diary/PostDiaryRequest.java
+++ b/src/spring-backend/web/src/main/java/com/memoblend/web/controller/dto/diary/PostDiaryRequest.java
@@ -1,8 +1,16 @@
 package com.memoblend.web.controller.dto.diary;
 
+import java.time.LocalDate;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
 /**
  * 日記の投稿リクエストクラスです。
  */
+@Data
+@AllArgsConstructor
 public class PostDiaryRequest {
-
+  private LocalDate date;
+  private String title;
+  private String content;
 }


### PR DESCRIPTION
## 本プルリクエストで実施したこと
- 日記のドメインモデルの追加
- 日記のコントローラに日記の取得と追加の追加
- 日記の取得と追加のdtoの中身を追加
- 日記の日時の変換utilクラスの追加
- api仕様書の再生成

## 本プルリクエストで実施していないこと
- アプリケーションサービスやインフラストラクチャの実装は行なっていません。

## 関連Issue、参考ページ
- 特になし
