### PR TITLE
日記が見つからなかった場合の例外を追加する

### DIFF
--- a/src/spring-backend/application-core/src/main/java/com/memoblend/applicationcore/applicationservice/DiaryApplicationService.java
+++ b/src/spring-backend/application-core/src/main/java/com/memoblend/applicationcore/applicationservice/DiaryApplicationService.java
@@ -1,15 +1,15 @@
 package com.memoblend.applicationcore.applicationservice;
 
 import java.time.LocalDate;
-import java.util.Optional;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import com.memoblend.applicationcore.diary.Diary;
+import com.memoblend.applicationcore.diary.DiaryNotFoundException;
 import com.memoblend.applicationcore.diary.DiaryRepository;
 import lombok.AllArgsConstructor;
 
 /**
- * 日記のサービスです。
+ * 日記のアプリケーションサービスです。
  */
 @Service
 @AllArgsConstructor
@@ -18,11 +18,28 @@ public class DiaryApplicationService {
   @Autowired
   private DiaryRepository diaryRepository;
 
-  public Diary getDiary(LocalDate date) {
-    Optional<Diary> diary = diaryRepository.findByDate(date);
-    return diary.get();
+  /**
+   * 日付を指定して、
+   * {@link Diary} を取得します。
+   * 
+   * @param date 日記を作成した日付。
+   * @return 条件に合う日記。
+   * @throws DiaryNotFoundException 日記が見つからない場合。
+   */
+  public Diary getDiary(LocalDate date) throws DiaryNotFoundException {
+    Diary diary = diaryRepository.findByDate(date);
+    if (diary == null) {
+      throw new DiaryNotFoundException(date);
+    }
+    return diary;
   }
 
+  /**
+   * 日記を追加します。
+   * 
+   * @param diary 追加する日記。
+   * @return 追加された日記。
+   */
   public Diary addDiary(Diary diary) {
     Diary addedDiary = diaryRepository.add(diary);
     return addedDiary;

--- a/src/spring-backend/application-core/src/main/java/com/memoblend/applicationcore/applicationservice/UserApplicationService.java
+++ b/src/spring-backend/application-core/src/main/java/com/memoblend/applicationcore/applicationservice/UserApplicationService.java
@@ -1,7 +1,7 @@
 package com.memoblend.applicationcore.applicationservice;
 
 /**
- * ユーザーのサービスです。
+ * ユーザーのアプリケーションサービスです。
  */
 public class UserApplicationService {
 

--- a/src/spring-backend/application-core/src/main/java/com/memoblend/applicationcore/diary/Diary.java
+++ b/src/spring-backend/application-core/src/main/java/com/memoblend/applicationcore/diary/Diary.java
@@ -17,19 +17,22 @@ public class Diary {
   @NotNull
   @NotBlank
   private long diaryId;
+
   @NotNull
   @NotBlank
   private long userId;
+
   @NotNull
   @NotBlank
   @Size(min = 1, max = 4, message = "{0}は1～30文字の範囲で入力してください")
   private String title;
+
   @NotNull
   @NotBlank
   @Size(min = 1, message = "{0}は1文字以上入力してください")
   private String content;
+
   @NotNull
   @NotBlank
   private LocalDate date;
-
 }

--- a/src/spring-backend/application-core/src/main/java/com/memoblend/applicationcore/diary/DiaryNotFoundException.java
+++ b/src/spring-backend/application-core/src/main/java/com/memoblend/applicationcore/diary/DiaryNotFoundException.java
@@ -1,5 +1,6 @@
 package com.memoblend.applicationcore.diary;
 
+import java.time.LocalDate;
 import com.memoblend.systemcommon.exception.LogicException;
 
 /**
@@ -7,13 +8,12 @@ import com.memoblend.systemcommon.exception.LogicException;
  */
 public class DiaryNotFoundException extends LogicException {
 
-    /**
-     * {@link DiaryNotFoundException} クラスのインスタンスを初期化します。
-     * 
-     * @param cause 原因例外。
-     */
-    public DiaryNotFoundException(Throwable cause) {
-        super(cause, "DIARY_NOT_FOUND", null, null);
-    }
-
+  /**
+   * {@link DiaryNotFoundException} クラスのインスタンスを初期化します。
+   * 
+   * @param date 日記を作成した日付。
+   */
+  public DiaryNotFoundException(LocalDate date) {
+    super(null, date.getYear() + "年" + date.getMonth() + "月" + date.getDayOfMonth() + "日の日記は存在しません", null, null);
+  }
 }

--- a/src/spring-backend/application-core/src/main/java/com/memoblend/applicationcore/diary/DiaryNotFoundException.java
+++ b/src/spring-backend/application-core/src/main/java/com/memoblend/applicationcore/diary/DiaryNotFoundException.java
@@ -1,0 +1,19 @@
+package com.memoblend.applicationcore.diary;
+
+import com.memoblend.systemcommon.exception.LogicException;
+
+/**
+ * 日記が見つからない場合の例外です。
+ */
+public class DiaryNotFoundException extends LogicException {
+
+    /**
+     * {@link DiaryNotFoundException} クラスのインスタンスを初期化します。
+     * 
+     * @param cause 原因例外。
+     */
+    public DiaryNotFoundException(Throwable cause) {
+        super(cause, "DIARY_NOT_FOUND", null, null);
+    }
+
+}

--- a/src/spring-backend/application-core/src/main/java/com/memoblend/applicationcore/diary/DiaryRepository.java
+++ b/src/spring-backend/application-core/src/main/java/com/memoblend/applicationcore/diary/DiaryRepository.java
@@ -1,20 +1,18 @@
 package com.memoblend.applicationcore.diary;
 
 import java.time.LocalDate;
-import java.util.Optional;
 
 /**
  * 日記のリポジトリのインターフェースです。
  */
 public interface DiaryRepository {
   /**
-   * ID を指定して、
-   * {@link Diary} を取得します。
+   * ID を指定して、 {@link Diary} を取得します。
    * 
    * @param date 日記を作成した日付。
    * @return 条件に合う日記。
    */
-  Optional<Diary> findByDate(LocalDate date);
+  Diary findByDate(LocalDate date);
 
   /**
    * 日記を追加します。

--- a/src/spring-backend/infrastructure/src/main/java/com/memoblend/infrastructure/repository/MyBatisDiaryRepository.java
+++ b/src/spring-backend/infrastructure/src/main/java/com/memoblend/infrastructure/repository/MyBatisDiaryRepository.java
@@ -1,7 +1,6 @@
 package com.memoblend.infrastructure.repository;
 
 import java.time.LocalDate;
-import java.util.Optional;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Repository;
 import com.memoblend.applicationcore.diary.Diary;
@@ -20,8 +19,8 @@ public class MyBatisDiaryRepository implements DiaryRepository {
   private DiaryMapper diaryMapper;
 
   @Override
-  public Optional<Diary> findByDate(LocalDate date) {
-    return Optional.of(diaryMapper.findByDate(date));
+  public Diary findByDate(LocalDate date) {
+    return diaryMapper.findByDate(date);
   }
 
   @Override

--- a/src/spring-backend/system-common/src/main/java/com/memoblend/systemcommon/exception/LogicException.java
+++ b/src/spring-backend/system-common/src/main/java/com/memoblend/systemcommon/exception/LogicException.java
@@ -1,0 +1,35 @@
+package com.memoblend.systemcommon.exception;
+
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * 業務例外を表す例外クラスです。
+ */
+@Getter
+@Setter
+public class LogicException extends Exception {
+
+  private String exceptionId = null;
+
+  private String[] frontMessageValue = null;
+
+  private String[] logMessageValue = null;
+
+  /**
+   * 原因例外、例外 ID 、メッセージ用プレースフォルダ（フロント用）、メッセージ用プレースフォルダ（ログ用）を指定して、
+   * {@link LogicException} クラスのインスタンスを初期化します。
+   *
+   * @param cause             原因例外。
+   * @param exceptionId       例外 ID 。
+   * @param frontMessageValue メッセージ用プレースフォルダ（フロント用）。
+   * @param logMessageValue   メッセージ用プレースフォルダ（ログ用）。
+   */
+  public LogicException(Throwable cause, String exceptionId,
+      String[] frontMessageValue, String[] logMessageValue) {
+    super(cause);
+    this.exceptionId = exceptionId;
+    this.frontMessageValue = frontMessageValue;
+    this.logMessageValue = logMessageValue;
+  }
+}

--- a/src/spring-backend/system-common/src/main/java/com/memoblend/systemcommon/exception/SystemException.java
+++ b/src/spring-backend/system-common/src/main/java/com/memoblend/systemcommon/exception/SystemException.java
@@ -1,0 +1,35 @@
+package com.memoblend.systemcommon.exception;
+
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * システム例外を表す例外クラスです。
+ */
+@Getter
+@Setter
+public class SystemException extends RuntimeException {
+
+  private String exceptionId = null;
+
+  private String[] frontMessageValue = null;
+
+  private String[] logMessageValue = null;
+
+  /**
+   * 原因例外、例外 ID 、メッセージ用プレースフォルダ（フロント用）、メッセージ用プレースフォルダ（ログ用）を指定して、
+   * {@link SystemException} クラスのインスタンスを初期化します。
+   *
+   * @param cause             原因例外。
+   * @param exceptionId       例外 ID 。
+   * @param frontMessageValue メッセージ用プレースフォルダ（フロント用）。
+   * @param logMessageValue   メッセージ用プレースフォルダ（ログ用）。
+   */
+  public SystemException(Throwable cause, String exceptionId,
+      String[] frontMessageValue, String[] logMessageValue) {
+    super(cause);
+    this.exceptionId = exceptionId;
+    this.frontMessageValue = frontMessageValue;
+    this.logMessageValue = logMessageValue;
+  }
+}

--- a/src/spring-backend/web/src/main/java/com/memoblend/web/controller/DiaryController.java
+++ b/src/spring-backend/web/src/main/java/com/memoblend/web/controller/DiaryController.java
@@ -3,6 +3,7 @@ package com.memoblend.web.controller;
 import org.springframework.web.bind.annotation.RestController;
 import com.memoblend.applicationcore.applicationservice.DiaryApplicationService;
 import com.memoblend.applicationcore.diary.Diary;
+import com.memoblend.applicationcore.diary.DiaryNotFoundException;
 import com.memoblend.systemcommon.util.LocalDateConverter;
 import com.memoblend.web.controller.dto.diary.GetDiaryResponse;
 import com.memoblend.web.controller.dto.diary.PostDiaryRequest;
@@ -39,7 +40,12 @@ public class DiaryController {
   @GetMapping("{date}")
   public ResponseEntity<GetDiaryResponse> getDiary(@PathVariable("date") long date) {
     LocalDate convertedDate = LocalDateConverter.longToLocalDate(date);
-    Diary diary = diaryApplicationService.getDiary(convertedDate);
+    Diary diary = null;
+    try {
+      diary = diaryApplicationService.getDiary(convertedDate);
+    } catch (DiaryNotFoundException e) {
+      return ResponseEntity.notFound().build();
+    }
     GetDiaryResponse response = DataTransferObjectConverter.diaryConverter(diary);
     return ResponseEntity.ok().body(response);
   }


### PR DESCRIPTION
## 本プルリクエストで実施したこと
- 日記の検索機能に日記が見つからなかった場合に404を返却するようにしました。

## 本プルリクエストで実施していないこと
- 特になし

## 関連Issue、参考ページ
- 特になし。
