### PR TITLE
log4j2を導入する

### DIFF
--- a/src/spring-backend/api-docs/web/api-specification.json
+++ b/src/spring-backend/api-docs/web/api-specification.json
@@ -18,6 +18,24 @@
   ],
   "paths": {
     "/api/diary": {
+      "get": {
+        "operationId": "getDiaries",
+        "responses": {
+          "200": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetDiariesResponse"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "tags": [
+          "Diary"
+        ]
+      },
       "post": {
         "operationId": "postDiary",
         "requestBody": {
@@ -42,25 +60,9 @@
             "description": "OK"
           }
         },
-        "tags": ["Diary"]
-      }
-    },
-    "/api/diary/": {
-      "get": {
-        "operationId": "getDiaries",
-        "responses": {
-          "200": {
-            "content": {
-              "*/*": {
-                "schema": {
-                  "$ref": "#/components/schemas/GetDiariesResponse"
-                }
-              }
-            },
-            "description": "OK"
-          }
-        },
-        "tags": ["Diary"]
+        "tags": [
+          "Diary"
+        ]
       }
     },
     "/api/diary/{date}": {
@@ -89,7 +91,9 @@
             "description": "OK"
           }
         },
-        "tags": ["Diary"]
+        "tags": [
+          "Diary"
+        ]
       }
     }
   },
@@ -107,7 +111,7 @@
             "type": "string",
             "format": "date"
           },
-          "diaryId": {
+          "id": {
             "type": "integer",
             "format": "int64"
           },
@@ -121,7 +125,13 @@
             "format": "int64"
           }
         },
-        "required": ["content", "date", "id", "title", "userId"]
+        "required": [
+          "content",
+          "date",
+          "id",
+          "title",
+          "userId"
+        ]
       },
       "GetDiariesResponse": {
         "type": "object",

--- a/src/spring-backend/api-docs/web/api-specification.json
+++ b/src/spring-backend/api-docs/web/api-specification.json
@@ -100,40 +100,28 @@
   "components": {
     "schemas": {
       "Diary": {
-        "type": [
-          "object"
-        ],
+        "type": "object",
         "properties": {
           "content": {
-            "type": [
-              "string"
-            ],
+            "type": "string",
             "maxLength": 2147483647,
             "minLength": 1
           },
           "date": {
-            "type": [
-              "string"
-            ],
+            "type": "string",
             "format": "date"
           },
           "diaryId": {
-            "type": [
-              "integer"
-            ],
+            "type": "integer",
             "format": "int64"
           },
           "title": {
-            "type": [
-              "string"
-            ],
+            "type": "string",
             "maxLength": 4,
             "minLength": 1
           },
           "userId": {
-            "type": [
-              "integer"
-            ],
+            "type": "integer",
             "format": "int64"
           }
         },
@@ -146,14 +134,10 @@
         ]
       },
       "GetDiariesResponse": {
-        "type": [
-          "object"
-        ],
+        "type": "object",
         "properties": {
           "diaries": {
-            "type": [
-              "array"
-            ],
+            "type": "array",
             "items": {
               "$ref": "#/components/schemas/Diary"
             }

--- a/src/spring-backend/application-core/src/main/java/com/memoblend/applicationcore/applicationservice/DiaryApplicationService.java
+++ b/src/spring-backend/application-core/src/main/java/com/memoblend/applicationcore/applicationservice/DiaryApplicationService.java
@@ -21,16 +21,17 @@ public class DiaryApplicationService {
   @Autowired
   private DiaryRepository diaryRepository;
 
+  private final Logger apLog = Logger.getLogger(LoggerConstant.APPLICATION_LOGGER);
+
   /**
    * 全ての日記を取得します。
    * 
    * @return 全ての日記。
    */
   public List<Diary> getDiaries() {
+    apLog.info("全ての日記を取得します。");
     return diaryRepository.findAll();
   }
-
-  private final Logger apLog = Logger.getLogger(LoggerConstant.APPLICATION_LOGGER);
 
   /**
    * 日付を指定して、

--- a/src/spring-backend/application-core/src/main/java/com/memoblend/applicationcore/applicationservice/DiaryApplicationService.java
+++ b/src/spring-backend/application-core/src/main/java/com/memoblend/applicationcore/applicationservice/DiaryApplicationService.java
@@ -1,11 +1,13 @@
 package com.memoblend.applicationcore.applicationservice;
 
 import java.time.LocalDate;
+import java.util.logging.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import com.memoblend.applicationcore.diary.Diary;
 import com.memoblend.applicationcore.diary.DiaryNotFoundException;
 import com.memoblend.applicationcore.diary.DiaryRepository;
+import com.memoblend.systemcommon.constant.LoggerConstant;
 import lombok.AllArgsConstructor;
 
 /**
@@ -18,6 +20,8 @@ public class DiaryApplicationService {
   @Autowired
   private DiaryRepository diaryRepository;
 
+  private final Logger apLog = Logger.getLogger(LoggerConstant.APPLICATION_LOGGER);
+
   /**
    * 日付を指定して、
    * {@link Diary} を取得します。
@@ -27,8 +31,10 @@ public class DiaryApplicationService {
    * @throws DiaryNotFoundException 日記が見つからない場合。
    */
   public Diary getDiary(LocalDate date) throws DiaryNotFoundException {
+    apLog.info(date.getYear() + "年" + date.getMonthValue() + "月" + date.getDayOfMonth() + "日の日記を取得します。");
     Diary diary = diaryRepository.findByDate(date);
     if (diary == null) {
+      apLog.info(date.getYear() + "年" + date.getMonthValue() + "月" + date.getDayOfMonth() + "日の日記が見つかりませんでした。");
       throw new DiaryNotFoundException(date);
     }
     return diary;
@@ -41,6 +47,8 @@ public class DiaryApplicationService {
    * @return 追加された日記。
    */
   public Diary addDiary(Diary diary) {
+    final LocalDate date = diary.getDate();
+    apLog.info(date.getYear() + "年" + date.getMonthValue() + "月" + date.getDayOfMonth() + "日の日記を追加します。");
     Diary addedDiary = diaryRepository.add(diary);
     return addedDiary;
   }

--- a/src/spring-backend/system-common/src/main/java/com/memoblend/systemcommon/constant/LoggerConstant.java
+++ b/src/spring-backend/system-common/src/main/java/com/memoblend/systemcommon/constant/LoggerConstant.java
@@ -4,6 +4,6 @@ package com.memoblend.systemcommon.constant;
  * ロガーの定数クラスです。
  */
 public class LoggerConstant {
-    /** アプリケーションロガーの名前 */
-    public static final String APPLICATION_LOGGER = "application.log";
+  /** アプリケーションロガーの名前です。 */
+  public static final String APPLICATION_LOGGER = "application.log";
 }

--- a/src/spring-backend/system-common/src/main/java/com/memoblend/systemcommon/constant/LoggerConstant.java
+++ b/src/spring-backend/system-common/src/main/java/com/memoblend/systemcommon/constant/LoggerConstant.java
@@ -1,0 +1,9 @@
+package com.memoblend.systemcommon.constant;
+
+/**
+ * ロガーの定数クラスです。
+ */
+public class LoggerConstant {
+    /** アプリケーションロガーの名前 */
+    public static final String APPLICATION_LOGGER = "application.log";
+}

--- a/src/spring-backend/web/src/main/java/com/memoblend/web/controller/DiaryController.java
+++ b/src/spring-backend/web/src/main/java/com/memoblend/web/controller/DiaryController.java
@@ -38,7 +38,7 @@ public class DiaryController {
    * 
    * @return 日記情報。
    */
-  @GetMapping("/")
+  @GetMapping("")
   public ResponseEntity<GetDiariesResponse> getDiaries() {
     List<Diary> diaries = diaryApplicationService.getDiaries();
     GetDiariesResponse response = DataTransferObjectConverter.diariesConverter(diaries);


### PR DESCRIPTION
## 本プルリクエストで実施したこと
- アプリケーションログライブラリであるlog4j2を導入しました。
- それに伴い、ロガー名を管理する定数クラスと、アプリケーションサービスにログ出力を行う処理を追加しました。

## 本プルリクエストで実施していないこと
- 日記の全件取得処理へのログ出力処理の追加。

## 関連Issue、参考ページ
- #87 
