### PR TITLE
プラグインで使用するtoolのバージョンをdependencies.gradleで管理するように変更

### DIFF
--- a/src/spring-backend/api-docs/web/api-specification.json
+++ b/src/spring-backend/api-docs/web/api-specification.json
@@ -34,7 +34,9 @@
           "200": {
             "content": {
               "*/*": {
-                "schema": {}
+                "schema": {
+                  "type": "object"
+                }
               }
             },
             "description": "OK"
@@ -80,71 +82,47 @@
   "components": {
     "schemas": {
       "GetDiaryResponse": {
-        "type": [
-          "object"
-        ],
+        "type": "object",
         "properties": {
           "content": {
-            "type": [
-              "string"
-            ]
+            "type": "string"
           },
           "date": {
-            "type": [
-              "string"
-            ],
+            "type": "string",
             "format": "date"
           },
           "diaryId": {
-            "type": [
-              "integer"
-            ],
+            "type": "integer",
             "format": "int64"
           },
           "title": {
-            "type": [
-              "string"
-            ]
+            "type": "string"
           },
           "userId": {
-            "type": [
-              "integer"
-            ],
+            "type": "integer",
             "format": "int64"
           }
         }
       },
       "PostDiaryRequest": {
-        "type": [
-          "object"
-        ],
+        "type": "object",
         "properties": {
           "content": {
-            "type": [
-              "string"
-            ]
+            "type": "string"
           },
           "date": {
-            "type": [
-              "string"
-            ],
+            "type": "string",
             "format": "date"
           },
           "diaryId": {
-            "type": [
-              "integer"
-            ],
+            "type": "integer",
             "format": "int64"
           },
           "title": {
-            "type": [
-              "string"
-            ]
+            "type": "string"
           },
           "userId": {
-            "type": [
-              "integer"
-            ],
+            "type": "integer",
             "format": "int64"
           }
         }

--- a/src/spring-backend/build.gradle
+++ b/src/spring-backend/build.gradle
@@ -9,7 +9,7 @@ buildscript {
 }
 
 plugins {
-  id 'com.github.spotbugs' version "${spotbugsVersion}" apply false
+  id 'com.github.spotbugs' version "$spotbugsVersion" apply false
 }
 
 subprojects {
@@ -36,15 +36,15 @@ subprojects {
   }
 
   jacoco {
-    toolVersion = '0.8.12'
+    toolVersion = "$jacocoToolVersion"
   }
   checkstyle {
-    toolVersion = '10.21.1'
+    toolVersion = "$checkstyleToolVersion"
     configDirectory = rootProject.file('config/checkstyle')
   } 
   spotbugs {
     excludeFilter.set(rootProject.file('config/spotbugs/exclude-filter.xml'))
-    toolVersion = '4.8.6'
+    toolVersion = "$spotbugsToolVersion"
     ignoreFailures = true
   }
 

--- a/src/spring-backend/dependencies.gradle
+++ b/src/spring-backend/dependencies.gradle
@@ -5,6 +5,11 @@ ext {
     springdocOpenapiGradlePluginVersion = "1.9.0"
     spotbugsVersion = "6.0.27"
 
+    // -- PLUGINS_TOOL
+    jacocoToolVersion = "0.8.12"
+    checkstyleToolVersion = "10.21.1"
+    spotbugsToolVersion = "4.9.0"
+
     // -- DEPENDENCIES
     springBatchTestVersion = "5.2.1"
     mybatisSpringBootStarterVersion = "3.0.4"
@@ -38,6 +43,7 @@ ext {
 
         lombok : "org.projectlombok:lombok",
         slf4j : "org.slf4j:slf4j-simple",
-        mybatisGenerator : "org.mybatis.generator:mybatis-generator-core:$mybatisGeneratorVersion"
+        mybatisGenerator : "org.mybatis.generator:mybatis-generator-core:$mybatisGeneratorVersion",
+        spotbugs : "com.github.spotbugs:spotbugs:$spotbugsToolVersion"
     ]
 }


### PR DESCRIPTION
## 本プルリクエストで実施したこと
- プラグインで使用するtoolバージョンがbuild.gradleにリテラルに指定されていたので、dependencies.gradleに集約しました。

## 本プルリクエストで実施していないこと
- 特になし。

## 関連Issue、参考ページ
- #90 
